### PR TITLE
add authors field to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ readme = "README.md"
 description = "No nonsense feature flagging system"
 repository = "https://github.com/vangheem/mr.flagly"
 homepage = "https://github.com/vangheem/mr.flagly"
+authors = [
+    {"name" = "Nathan Van Gheem", "email" = "vangheem@gmail.com>"},
+]


### PR DESCRIPTION
To make it show up on the pypi page of the project.

Fixing the previous PR #1 