### PR TITLE
Fix bug that returned the default value when no variants are matched

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -148,6 +148,8 @@ impl FlagService {
                         && value.iter().any(|v| v == ucontext.get(key).unwrap())
                     {
                         return true;
+                    } else {
+                        return false;
                     }
                 }
             }


### PR DESCRIPTION
If you used default = True when checking a flag, even if the flag was defined, you always received the default, With default=False, it worked, but because it was returning also the default, and true on match