### PR TITLE
Make Python support optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "mrflagly"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "httptest",
  "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mrflagly"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "MIT"
 description = "No nonsense feature flagging system"
@@ -11,11 +11,15 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "mrflagly"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
 httptest = "0.15.4"
 json = "0.12.4"
-pyo3 = { version = "0.18.0", features = ["extension-module"] }
+pyo3 = { version = "0.18.0", features = ["extension-module"], optional = true }
 ureq = "2.6.2"
+
+[features]
+default = ["python"]
+python = ["dep:pyo3"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "python")]
 pub mod bindings;
 pub mod service;
 
+#[cfg(feature = "python")]
 pub use bindings::*;
 pub use service::*;


### PR DESCRIPTION
Make compilation of Python bindings optional (defaults to compile them).